### PR TITLE
Fetch list

### DIFF
--- a/src/Redux/Rockets/RocketSlice.js
+++ b/src/Redux/Rockets/RocketSlice.js
@@ -1,10 +1,29 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+
+const baseUrl = 'https://api.spacexdata.com/v3/rockets';
+
+export const fetchRockets = createAsyncThunk(
+  'rockets/fetchRockets',
+  async () => {
+    const response = await fetch(baseUrl);
+    const rockets = await response.json();
+    return rockets;
+  },
+);
 
 const RocketSlice = createSlice({
   name: 'rockets',
-  initialState: [],
+  initialState: {
+    rockets: [],
+  },
   reducers: {},
-  extraReducers: () => {
+  extraReducers: {
+    /* eslint-disable */
+    [fetchRockets.fulfilled]: (state, action) => {
+      state.status = "succeeded";
+      state.rockets = action.payload;
+    },
+    /* eslint-enable */
   },
 });
 

--- a/src/Views/Rockets.js
+++ b/src/Views/Rockets.js
@@ -1,7 +1,10 @@
 import React from 'react';
+import ListRockets from '../components/ListRockets';
 
 const Rockets = () => (
-  <div>Rockets</div>
+  <div>
+    <ListRockets />
+  </div>
 );
 
 export default Rockets;

--- a/src/components/ListRockets.js
+++ b/src/components/ListRockets.js
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { fetchRockets } from '../Redux/Rockets/RocketSlice';
+
+function ListRockets() {
+  const rockets = useSelector((state) => state.rockets.rockets);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(fetchRockets());
+  }, [dispatch]);
+
+  return (
+    <div className="rocket_container">
+      {rockets.map((rocket) => (
+        <div key={rocket.id} className="rocket_row">
+          <img src={rocket.flickr_images[0]} alt={rocket.name} />
+          <div className="rocket-col">
+            <h2>{rocket.rocket_name}</h2>
+            <p>{rocket.description}</p>
+            <button type="button">Reserve Rocket</button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default ListRockets;

--- a/src/components/global.md
+++ b/src/components/global.md
@@ -1,1 +1,0 @@
-// this is for global components that may use in diffrent page

--- a/src/index.css
+++ b/src/index.css
@@ -53,3 +53,51 @@ body {
   width: 50px;
   height: 50px;
 }
+
+.rocket_container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.rocket_row {
+  display: flex;
+  justify-content: flex-start;
+  flex-direction: row;
+  gap: 20px;
+}
+
+.rocket-col {
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
+  flex-direction: column;
+}
+
+.rocket_row img {
+  width: 400px;
+  height: 300px;
+}
+
+.rocket_row h2 {
+  font-size: 30px;
+  padding: 0;
+  margin: 0;
+}
+
+.rocket_row p {
+  font-size: 20px;
+  width: 90%;
+}
+
+.rocket_row button {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 5px;
+  background-color: rgb(27, 80, 255);
+  color: #fff;
+  font-size: 18px;
+  cursor: pointer;
+}


### PR DESCRIPTION
[[4pt] Fetch rockets - Fetch data#85](https://github.com/whiteWolfx99/React-Capstone-Group/issues/85)
[[4pt] Display rockets - Lists render#81](https://github.com/whiteWolfx99/React-Capstone-Group/issues/81)

- Fetch data from the Rockets endpoint (https://api.spacexdata.com/v3/rockets) when the application starts (as Rockets is the default view).
- Once the data are fetched, dispatch an action to store the selected data in Redux store:
id
name
type
flickr_images

- Use `useSelector()` Redux Hook to select the state slices and render lists of rockets in corresponding routes. i.e.:
```javascript
// get rockets data from the store
const rockets = useSelector(state => state.rockets);
```

- You can style the whole application "by hand" or you could use [React Bootstrap](https://react-bootstrap.github.io/), a UI library that could speed up the process. This is a popular library and working with its components would be good practice.
- Render a list of rockets (as per design). For the image of a rocket use the first image in the array of `flickr_images`.
